### PR TITLE
Add default value to performance id in event CRUD

### DIFF
--- a/app/Http/Controllers/Admin/PerformanceCrudController.php
+++ b/app/Http/Controllers/Admin/PerformanceCrudController.php
@@ -51,6 +51,8 @@ class PerformanceCrudController extends CrudController
      */
     protected function setupListOperation()
     {
+        $this->crud->addButtonFromView('line', 'add_event', 'add_event', 'beginning');
+
         $this->crud->addColumns($this->getConfig(true, false));
     }
 

--- a/resources/views/vendor/backpack/crud/buttons/add_event.blade.php
+++ b/resources/views/vendor/backpack/crud/buttons/add_event.blade.php
@@ -1,0 +1,1 @@
+<a href="{{route('event.create', [ 'performance_id' => $entry->getKey() ])}}" class="btn btn-sm btn-link"><i class="la la-plus"></i> Add event</a>


### PR DESCRIPTION
This feature makes it easier to create events about a certain performance. You can click the button add event on the performance list and the selected performance will automatically be selected in the event form.